### PR TITLE
Serde and bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
-# 0.2 (unreleased)
+# 0.3 (unreleased)
+
+## API changes
+
+* Added opt-in serde support to facilitate session and ack management (storing subscriptions and
+  pids to disk or database). The actual encode()/decode() APIs are unchanged.
+* Upgrated bytes dependency to 0.5. This brings growable buffers and a nicer API, [amongst other
+  things](https://github.com/tokio-rs/bytes/blob/master/CHANGELOG.md).
+* Implemented `Default for Pid`, `From<u16> for Pid`, and `TryFrom<Pid> for u16`. The `try_from()`
+  method already existed but now comes from the `std::convert::TryFrom` trait.
+
+## Bugfixes
+
+* Fix off-by one error when adding to a Pid wraps over.
+
+## Other changes
+
+* The minimum rust version is now 1.39.
+* Improved `Pid` docs.
+
+
+# 0.2 (2019-10-25)
 
 This is a fairly large release with API fixes and improvements, bug fixes, and much better test
 coverage and documentation.
@@ -21,6 +42,7 @@ coverage and documentation.
 * Lots of corner-case bugfixes, particularly when decoding partial or corrupted data.
 * The minimum rust version is now 1.32.
 * Raised `mqttrs`'s bus factor to 2 ;)
+
 
 # 0.1.4 (2019-09-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   things](https://github.com/tokio-rs/bytes/blob/master/CHANGELOG.md).
 * Implemented `Default for Pid`, `From<u16> for Pid`, and `TryFrom<Pid> for u16`. The `try_from()`
   method already existed but now comes from the `std::convert::TryFrom` trait.
+* `encode()` now takes anything that implements the `BufMut` trait, not just a `ByteMut` struct. For
+  technical reasons, `decode()` still takes `BytesMut`.
 
 ## Bugfixes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,13 @@ keywords = ["mqtt", "pubsub", "publish-subscribe", "codec"]
 categories = ["encoding", "network-programming"]
 license = "Apache-2.0"
 
+[features]
+# Implements serde::{Serialize,Deserialize} on mqttrs::Pid.
+derive = ["serde"]
+
 [dependencies]
 bytes = "0.4"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 proptest = "0.9.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 derive = ["serde"]
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.5"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ frameworks like [tokio](https://tokio.rs/). It is strict when decoding (e.g. ret
 encountering reserved values) and encoding (the API makes it impossible to generate an illegal
 packet).
 
-`Mqttrs` currently requires [Rust >= 1.32](https://www.rust-lang.org/learn/get-started) and supports
+`Mqttrs` currently requires [Rust >= 1.39](https://www.rust-lang.org/learn/get-started) and supports
 [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html). Support for [MQTT
 5](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html) is planned for a future version.
 
 
 ## Usage
 
-Add `mqttrs = "0.2"` to your `Cargo.toml`.
+Add `mqttrs = "0.2"` and `bytes = "0.5"` to your `Cargo.toml`.
 
 ```rust
 use mqttrs::*;
@@ -43,7 +43,7 @@ assert_eq!(Ok(Some(pkt)), decode(&mut buf));
 // Example decode failures.
 let mut incomplete = encoded.split_to(10);
 assert_eq!(Ok(None), decode(&mut incomplete));
-let mut garbage = BytesMut::from(vec![0u8,0,0,0]);
+let mut garbage = BytesMut::from(&[0u8,0,0,0] as &[u8]);
 assert_eq!(Err(Error::InvalidHeader), decode(&mut garbage));
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ packet).
 [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html). Support for [MQTT
 5](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html) is planned for a future version.
 
+
 ## Usage
 
 Add `mqttrs = "0.2"` to your `Cargo.toml`.
@@ -45,3 +46,14 @@ assert_eq!(Ok(None), decode(&mut incomplete));
 let mut garbage = BytesMut::from(vec![0u8,0,0,0]);
 assert_eq!(Err(Error::InvalidHeader), decode(&mut garbage));
 ```
+
+## Optional [serde](https://serde.rs/) support.
+
+Use  `mqttrs = { version = "0.2", features = [ "derive" ] }` in your `Cargo.toml`.
+
+Enabling this features adds `#[derive(Deserialize, Serialize)]` to some `mqttrs` types. This
+simplifies storing those structs in a database or file, typically to implement session support (qos,
+subscriptions...).
+
+This doesn't add mqtt as a serde data format; you still need to use the `mqttrs::{decode,encode}`
+functions.

--- a/src/codec_test.rs
+++ b/src/codec_test.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use bytes::BytesMut;
 use proptest::{bool, collection::vec, num::*, prelude::*};
+use std::convert::TryFrom;
 
 // Proptest strategies to generate packet elements
 prop_compose! {

--- a/src/codec_test.rs
+++ b/src/codec_test.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use bytes::BufMut;
 use bytes::BytesMut;
 use proptest::{bool, collection::vec, num::*, prelude::*};
 
@@ -164,20 +163,25 @@ macro_rules! impl_proptests {
                 let decoded = decode(&mut encoded.clone().split_off(encoded.len() - 1)).unwrap();
                 prop_assert!(decoded.is_none(), "partial decode {:?} -> {:?}", encoded, decoded);
 
+                // TODO: The next part can't fail anymore because ByteMut 0.5 grows as
+                // needed. However, we want to restore support for non-growable buffers eventually
+                // (especially for no-std), so I'm keeping this code around until decode() is
+                // modified to accept other buffer types.
+
                 // Check that encoding into a small buffer fails cleanly
-                buf.clear();
-                buf.split_off(encoded.len());
-                prop_assert!(encoded.len() == buf.remaining_mut() && buf.is_empty(),
-                             "Wrong buffer init1 {}/{}/{}", encoded.len(), buf.remaining_mut(), buf.is_empty());
-                prop_assert!(encode(&pkt, &mut buf).is_ok(), "exact buffer capacity {}", buf.capacity());
-                for l in (0..encoded.len()).rev() {
-                    buf.clear();
-                    buf.split_to(1);
-                    prop_assert!(l == buf.remaining_mut() && buf.is_empty(),
-                                 "Wrong buffer init2 {}/{}/{}", l, buf.remaining_mut(), buf.is_empty());
-                    prop_assert_eq!(Err(Error::WriteZero), encode(&pkt, &mut buf),
-                                    "small buffer capacity {}/{}", buf.capacity(), encoded.len());
-                }
+                //buf.clear();
+                //buf.split_off(encoded.len());
+                //prop_assert!(encoded.len() == buf.remaining_mut() && buf.is_empty(),
+                //             "Wrong buffer init1 {}/{}/{}", encoded.len(), buf.remaining_mut(), buf.is_empty());
+                //prop_assert!(encode(&pkt, &mut buf).is_ok(), "exact buffer capacity {}", buf.capacity());
+                //for l in (0..encoded.len()).rev() {
+                //    buf.clear();
+                //    buf.split_to(1);
+                //    prop_assert!(l == buf.remaining_mut() && buf.is_empty(),
+                //                 "Wrong buffer init2 {}/{}/{}", l, buf.remaining_mut(), buf.is_empty());
+                //    prop_assert_eq!(Err(Error::WriteZero), encode(&pkt, &mut buf),
+                //                    "small buffer capacity {}/{}", buf.capacity(), encoded.len());
+                //}
             }
         }
     };

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -15,7 +15,7 @@ use bytes::{BufMut, BytesMut};
 ///    payload: "hello".into(),
 /// }.into();
 ///
-/// // Allocate a appropriately-sized buffer.
+/// // Allocate buffer (should be appropriately-sized or able to grow as needed).
 /// let mut buf = BytesMut::with_capacity(1024);
 ///
 /// // Write bytes corresponding to `&Packet` into the `BytesMut`.
@@ -26,71 +26,77 @@ use bytes::{BufMut, BytesMut};
 /// ```
 ///
 /// [Packet]: ../enum.Packet.html
-/// [BytesMut]: https://docs.rs/bytes/0.4.12/bytes/struct.BytesMut.html
-pub fn encode(packet: &Packet, buffer: &mut BytesMut) -> Result<(), Error> {
+/// [BytesMut]: https://docs.rs/bytes/0.5.3/bytes/struct.BytesMut.html
+pub fn encode(packet: &Packet, buf: &mut BytesMut) -> Result<(), Error> {
     match packet {
-        Packet::Connect(connect) => connect.to_buffer(buffer),
-        Packet::Connack(connack) => connack.to_buffer(buffer),
-        Packet::Publish(publish) => publish.to_buffer(buffer),
+        Packet::Connect(connect) => connect.to_buffer(buf),
+        Packet::Connack(connack) => connack.to_buffer(buf),
+        Packet::Publish(publish) => publish.to_buffer(buf),
         Packet::Puback(pid) => {
-            check_remaining(buffer, 4)?;
-            let header_u8 = 0b01000000 as u8;
-            let length = 0b00000010 as u8;
-            buffer.put(header_u8);
-            buffer.put(length);
-            pid.to_buffer(buffer)
+            check_remaining(buf, 4)?;
+            let header: u8 = 0b01000000;
+            let length: u8 = 2;
+            buf.put_u8(header);
+            buf.put_u8(length);
+            pid.to_buffer(buf)
         }
         Packet::Pubrec(pid) => {
-            check_remaining(buffer, 4)?;
-            let header_u8 = 0b01010000 as u8;
-            let length = 0b00000010 as u8;
-            buffer.put(header_u8);
-            buffer.put(length);
-            pid.to_buffer(buffer)
+            check_remaining(buf, 4)?;
+            let header: u8 = 0b01010000;
+            let length: u8 = 2;
+            buf.put_u8(header);
+            buf.put_u8(length);
+            pid.to_buffer(buf)
         }
         Packet::Pubrel(pid) => {
-            check_remaining(buffer, 4)?;
-            let header_u8 = 0b01100010 as u8;
-            let length = 0b00000010 as u8;
-            buffer.put(header_u8);
-            buffer.put(length);
-            pid.to_buffer(buffer)
+            check_remaining(buf, 4)?;
+            let header: u8 = 0b01100010;
+            let length: u8 = 2;
+            buf.put_u8(header);
+            buf.put_u8(length);
+            pid.to_buffer(buf)
         }
         Packet::Pubcomp(pid) => {
-            check_remaining(buffer, 4)?;
-            let header_u8 = 0b01110000 as u8;
-            let length = 0b00000010 as u8;
-            buffer.put(header_u8);
-            buffer.put(length);
-            pid.to_buffer(buffer)
+            check_remaining(buf, 4)?;
+            let header: u8 = 0b01110000;
+            let length: u8 = 2;
+            buf.put_u8(header);
+            buf.put_u8(length);
+            pid.to_buffer(buf)
         }
-        Packet::Subscribe(subscribe) => subscribe.to_buffer(buffer),
-        Packet::Suback(suback) => suback.to_buffer(buffer),
-        Packet::Unsubscribe(unsub) => unsub.to_buffer(buffer),
+        Packet::Subscribe(subscribe) => subscribe.to_buffer(buf),
+        Packet::Suback(suback) => suback.to_buffer(buf),
+        Packet::Unsubscribe(unsub) => unsub.to_buffer(buf),
         Packet::Unsuback(pid) => {
-            check_remaining(buffer, 4)?;
-            let header_u8 = 0b10110000 as u8;
-            let length = 0b00000010 as u8;
-            buffer.put(header_u8);
-            buffer.put(length);
-            pid.to_buffer(buffer)
+            check_remaining(buf, 4)?;
+            let header: u8 = 0b10110000;
+            let length: u8 = 2;
+            buf.put_u8(header);
+            buf.put_u8(length);
+            pid.to_buffer(buf)
         }
         Packet::Pingreq => {
-            check_remaining(buffer, 2)?;
-            buffer.put(0b11000000 as u8);
-            buffer.put(0b00000000 as u8);
+            check_remaining(buf, 2)?;
+            let header: u8 = 0b11000000;
+            let length: u8 = 0;
+            buf.put_u8(header);
+            buf.put_u8(length);
             Ok(())
         }
         Packet::Pingresp => {
-            check_remaining(buffer, 2)?;
-            buffer.put(0b11010000 as u8);
-            buffer.put(0b00000000 as u8);
+            check_remaining(buf, 2)?;
+            let header: u8 = 0b11010000;
+            let length: u8 = 0;
+            buf.put_u8(header);
+            buf.put_u8(length);
             Ok(())
         }
         Packet::Disconnect => {
-            check_remaining(buffer, 2)?;
-            buffer.put(0b11100000 as u8);
-            buffer.put(0b00000000 as u8);
+            check_remaining(buf, 2)?;
+            let header: u8 = 0b11100000;
+            let length: u8 = 0;
+            buf.put_u8(header);
+            buf.put_u8(length);
             Ok(())
         }
     }
@@ -98,8 +104,8 @@ pub fn encode(packet: &Packet, buffer: &mut BytesMut) -> Result<(), Error> {
 
 /// Check wether buffer has `len` bytes of write capacity left. Use this to return a clean
 /// Result::Err instead of panicking.
-pub(crate) fn check_remaining(buffer: &BytesMut, len: usize) -> Result<(), Error> {
-    if buffer.remaining_mut() < len {
+pub(crate) fn check_remaining(buf: &BytesMut, len: usize) -> Result<(), Error> {
+    if buf.remaining_mut() < len {
         Err(Error::WriteZero)
     } else {
         Ok(())
@@ -107,12 +113,12 @@ pub(crate) fn check_remaining(buffer: &BytesMut, len: usize) -> Result<(), Error
 }
 
 /// http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718023
-pub(crate) fn write_length(len: usize, buffer: &mut BytesMut) -> Result<(), Error> {
+pub(crate) fn write_length(len: usize, buf: &mut BytesMut) -> Result<(), Error> {
     match len {
-        0..=127 => check_remaining(buffer, len + 1)?,
-        128..=16383 => check_remaining(buffer, len + 2)?,
-        16384..=2097151 => check_remaining(buffer, len + 3)?,
-        2097152..=268435455 => check_remaining(buffer, len + 4)?,
+        0..=127 => check_remaining(buf, len + 1)?,
+        128..=16383 => check_remaining(buf, len + 2)?,
+        16384..=2097151 => check_remaining(buf, len + 3)?,
+        2097152..=268435455 => check_remaining(buf, len + 4)?,
         _ => return Err(Error::InvalidLength),
     }
     let mut done = false;
@@ -123,18 +129,18 @@ pub(crate) fn write_length(len: usize, buffer: &mut BytesMut) -> Result<(), Erro
         if x > 0 {
             byte = byte | 128;
         }
-        buffer.put(byte as u8);
+        buf.put_u8(byte);
         done = x <= 0;
     }
     Ok(())
 }
 
-pub(crate) fn write_bytes(bytes: &[u8], buffer: &mut BytesMut) -> Result<(), Error> {
-    buffer.put_u16_be(bytes.len() as u16);
-    buffer.put_slice(bytes);
+pub(crate) fn write_bytes(bytes: &[u8], buf: &mut BytesMut) -> Result<(), Error> {
+    buf.put_u16(bytes.len() as u16);
+    buf.put_slice(bytes);
     Ok(())
 }
 
-pub(crate) fn write_string(string: &str, buffer: &mut BytesMut) -> Result<(), Error> {
-    write_bytes(string.as_bytes(), buffer)
+pub(crate) fn write_string(string: &str, buf: &mut BytesMut) -> Result<(), Error> {
+    write_bytes(string.as_bytes(), buf)
 }

--- a/src/encoder_test.rs
+++ b/src/encoder_test.rs
@@ -1,6 +1,22 @@
 use crate::*;
 use bytes::BytesMut;
 
+macro_rules! assert_decode {
+    ($res:pat, $pkt:expr) => {
+        let mut buf = BytesMut::with_capacity(1024);
+        encode($pkt, &mut buf).unwrap();
+        match decode(&mut buf) {
+            Ok(Some($res)) => (),
+            err => assert!(
+                false,
+                "Expected: Ok(Some({}))  got: {:?}",
+                stringify!($res),
+                err
+            ),
+        }
+    };
+}
+
 #[test]
 fn test_connect() {
     let packet = Connect {
@@ -12,12 +28,7 @@ fn test_connect() {
         username: None,
         password: None,
     };
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&packet.into(), &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Connect(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Connect(_), &packet.into());
 }
 
 #[test]
@@ -26,12 +37,7 @@ fn test_connack() {
         session_present: true,
         code: ConnectReturnCode::Accepted,
     };
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&packet.into(), &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Connack(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Connack(_), &packet.into());
 }
 
 #[test]
@@ -43,56 +49,31 @@ fn test_publish() {
         topic_name: "asdf".to_string(),
         payload: vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8],
     };
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&packet.into(), &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Publish(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Publish(_), &packet.into());
 }
 
 #[test]
 fn test_puback() {
     let packet = Packet::Puback(Pid::try_from(19).unwrap());
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&packet, &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Puback(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Puback(_), &packet);
 }
 
 #[test]
 fn test_pubrec() {
     let packet = Packet::Pubrec(Pid::try_from(19).unwrap());
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&packet, &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Pubrec(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Pubrec(_), &packet);
 }
 
 #[test]
 fn test_pubrel() {
     let packet = Packet::Pubrel(Pid::try_from(19).unwrap());
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&packet, &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Pubrel(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Pubrel(_), &packet);
 }
 
 #[test]
 fn test_pubcomp() {
     let packet = Packet::Pubcomp(Pid::try_from(19).unwrap());
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&packet, &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Pubcomp(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Pubcomp(_), &packet);
 }
 
 #[test]
@@ -105,12 +86,7 @@ fn test_subscribe() {
         pid: Pid::try_from(345).unwrap(),
         topics: vec![stopic],
     };
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&Packet::Subscribe(packet), &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Subscribe(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Subscribe(_), &Packet::Subscribe(packet));
 }
 
 #[test]
@@ -120,12 +96,7 @@ fn test_suback() {
         pid: Pid::try_from(12321).unwrap(),
         return_codes: vec![return_code],
     };
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&Packet::Suback(packet), &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Suback(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Suback(_), &Packet::Suback(packet));
 }
 
 #[test]
@@ -134,51 +105,26 @@ fn test_unsubscribe() {
         pid: Pid::try_from(12321).unwrap(),
         topics: vec!["a/b".to_string()],
     };
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&Packet::Unsubscribe(packet), &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Unsubscribe(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Unsubscribe(_), &Packet::Unsubscribe(packet));
 }
 
 #[test]
 fn test_unsuback() {
     let packet = Packet::Unsuback(Pid::try_from(19).unwrap());
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&packet, &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Unsuback(_))) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Unsuback(_), &packet);
 }
 
 #[test]
 fn test_ping_req() {
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&Packet::Pingreq, &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Pingreq)) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Pingreq, &Packet::Pingreq);
 }
 
 #[test]
 fn test_ping_resp() {
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&Packet::Pingresp, &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Pingresp)) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Pingresp, &Packet::Pingresp);
 }
 
 #[test]
 fn test_disconnect() {
-    let mut buffer = BytesMut::with_capacity(1024);
-    encode(&Packet::Disconnect, &mut buffer).unwrap();
-    match decode(&mut buffer) {
-        Ok(Some(Packet::Disconnect)) => assert!(true),
-        err => assert!(false, err),
-    }
+    assert_decode!(Packet::Disconnect, &Packet::Disconnect);
 }

--- a/src/encoder_test.rs
+++ b/src/encoder_test.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use bytes::BytesMut;
+use std::convert::TryFrom;
 
 macro_rules! assert_decode {
     ($res:pat, $pkt:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! // Example decode failures.
 //! let mut incomplete = encoded.split_to(10);
 //! assert_eq!(Ok(None), decode(&mut incomplete));
-//! let mut garbage = BytesMut::from(vec![0u8,0,0,0]);
+//! let mut garbage = BytesMut::from(&[0u8,0,0,0] as &[u8]);
 //! assert_eq!(Err(Error::InvalidHeader), decode(&mut garbage));
 //! ```
 //!
@@ -42,7 +42,7 @@
 //! [Packet]: enum.Packet.html
 //! [encode()]: fn.encode.html
 //! [decode()]: fn.decode.html
-//! [bytes::BytesMut]: https://docs.rs/bytes/0.4.12/bytes/struct.BytesMut.html
+//! [bytes::BytesMut]: https://docs.rs/bytes/0.5.3/bytes/struct.BytesMut.html
 
 mod connect;
 mod decoder;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -7,6 +7,7 @@ use crate::*;
 ///
 /// ```
 /// # use mqttrs::*;
+/// # use std::convert::TryFrom;
 /// // Simplest form
 /// let pkt = Packet::Connack(Connack { session_present: false,
 ///                                     code: ConnectReturnCode::Accepted });

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -23,16 +23,15 @@ impl Publish {
             QoS::ExactlyOnce => QosPid::ExactlyOnce(Pid::from_buffer(buf)?),
         };
 
-        let payload = buf.to_vec();
         Ok(Publish {
             dup: header.dup,
             qospid,
             retain: header.retain,
             topic_name,
-            payload,
+            payload: buf.to_vec(),
         })
     }
-    pub(crate) fn to_buffer(&self, buf: &mut BytesMut) -> Result<(), Error> {
+    pub(crate) fn to_buffer(&self, buf: &mut impl BufMut) -> Result<(), Error> {
         // Header
         let mut header: u8 = match self.qospid {
             QosPid::AtMostOnce => 0b00110000,

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -1,5 +1,7 @@
 use crate::{decoder::*, encoder::*, *};
 use bytes::{Buf, BufMut, BytesMut, IntoBuf};
+#[cfg(feature = "derive")]
+use serde::{Deserialize, Serialize};
 
 /// Subscribe topic.
 ///
@@ -7,6 +9,7 @@ use bytes::{Buf, BufMut, BytesMut, IntoBuf};
 ///
 /// [Subscribe]: struct.Subscribe.html
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "derive", derive(Serialize, Deserialize))]
 pub struct SubscribeTopic {
     pub topic_path: String,
     pub qos: QoS,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@ use bytes::{Buf, BufMut, BytesMut};
 #[cfg(feature = "derive")]
 use serde::{Deserialize, Serialize};
 use std::{
+    convert::TryFrom,
     error::Error as ErrorTrait,
     fmt,
     io::{Error as IoError, ErrorKind},
@@ -68,10 +69,22 @@ impl From<IoError> for Error {
 /// For packets with [`QoS::AtLeastOne` or `QoS::ExactlyOnce`] delivery.
 ///
 /// ```rust
-/// # use mqttrs::{Pid, Packet};
-/// let pid = Pid::try_from(42).expect("illegal pid value");
-/// let next_pid = pid + 1;
-/// let pending_acks = std::collections::HashMap::<Pid, Packet>::new();
+/// # use mqttrs::{Packet, Pid, QosPid};
+/// # use std::convert::TryFrom;
+/// #[derive(Default)]
+/// struct Session {
+///    pid: Pid,
+/// }
+/// impl Session {
+///    pub fn next_pid(&mut self) -> Pid {
+///        self.pid = self.pid + 1;
+///        self.pid
+///    }
+/// }
+///
+/// let mut sess = Session::default();
+/// assert_eq!(2, sess.next_pid().get());
+/// assert_eq!(Pid::try_from(3).unwrap(), sess.next_pid());
 /// ```
 ///
 /// The spec ([MQTT-2.3.1-1], [MQTT-2.2.1-3]) disallows a pid of 0.
@@ -87,14 +100,6 @@ impl Pid {
     pub fn new() -> Self {
         Pid(NonZeroU16::new(1).unwrap())
     }
-    /// Returns a new `Pid` with specified value.
-    // Not using std::convert::TryFrom so that don't have to depend on rust 1.34.
-    pub fn try_from(u: u16) -> Result<Self, Error> {
-        match NonZeroU16::new(u) {
-            Some(nz) => Ok(Pid(nz)),
-            None => Err(Error::InvalidPid),
-        }
-    }
     /// Get the `Pid` as a raw `u16`.
     pub fn get(self) -> u16 {
         self.0.get()
@@ -106,8 +111,14 @@ impl Pid {
         Ok(buf.put_u16(self.get()))
     }
 }
+impl Default for Pid {
+    fn default() -> Pid {
+        Pid::new()
+    }
+}
 impl std::ops::Add<u16> for Pid {
     type Output = Pid;
+    /// Adding a `u16` to a `Pid` will wrap around and avoid 0.
     fn add(self, u: u16) -> Pid {
         let n = match self.get().overflowing_add(u) {
             (n, false) => n,
@@ -118,6 +129,7 @@ impl std::ops::Add<u16> for Pid {
 }
 impl std::ops::Sub<u16> for Pid {
     type Output = Pid;
+    /// Adding a `u16` to a `Pid` will wrap around and avoid 0.
     fn sub(self, u: u16) -> Pid {
         let n = match self.get().overflowing_sub(u) {
             (0, _) => std::u16::MAX,
@@ -125,6 +137,22 @@ impl std::ops::Sub<u16> for Pid {
             (n, true) => n - 1,
         };
         Pid(NonZeroU16::new(n).unwrap())
+    }
+}
+impl From<Pid> for u16 {
+    /// Convert `Pid` to `u16`.
+    fn from(p: Pid) -> Self {
+        p.0.get()
+    }
+}
+impl TryFrom<u16> for Pid {
+    type Error = Error;
+    /// Convert `u16` to `Pid`. Will fail for value 0.
+    fn try_from(u: u16) -> Result<Self, Error> {
+        match NonZeroU16::new(u) {
+            Some(nz) => Ok(Pid(nz)),
+            None => Err(Error::InvalidPid),
+        }
     }
 }
 
@@ -208,6 +236,7 @@ impl QosPid {
 #[cfg(test)]
 mod test {
     use crate::Pid;
+    use std::convert::TryFrom;
 
     #[test]
     fn pid_add_sub() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, BufMut, BytesMut, IntoBuf};
+use bytes::{Buf, BufMut, BytesMut};
 #[cfg(feature = "derive")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -100,10 +100,10 @@ impl Pid {
         self.0.get()
     }
     pub(crate) fn from_buffer(buf: &mut BytesMut) -> Result<Self, Error> {
-        Self::try_from(buf.split_to(2).into_buf().get_u16_be())
+        Self::try_from(buf.split_to(2).get_u16())
     }
     pub(crate) fn to_buffer(self, buf: &mut BytesMut) -> Result<(), Error> {
-        Ok(buf.put_u16_be(self.get()))
+        Ok(buf.put_u16(self.get()))
     }
 }
 impl std::ops::Add<u16> for Pid {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
 use bytes::{Buf, BufMut, BytesMut, IntoBuf};
+#[cfg(feature = "derive")]
+use serde::{Deserialize, Serialize};
 use std::{
     error::Error as ErrorTrait,
     fmt,
@@ -78,6 +80,7 @@ impl From<IoError> for Error {
 /// [MQTT-2.3.1-1]: https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718025
 /// [MQTT-2.2.1-3]: https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901026
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "derive", derive(Serialize, Deserialize))]
 pub struct Pid(NonZeroU16);
 impl Pid {
     /// Returns a new `Pid` with value `1`.
@@ -129,6 +132,7 @@ impl std::ops::Sub<u16> for Pid {
 ///
 /// [Quality of Service]: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718099
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "derive", derive(Serialize, Deserialize))]
 pub enum QoS {
     /// `QoS 0`. No ack needed.
     AtMostOnce,
@@ -163,6 +167,7 @@ impl QoS {
 /// [`QoS`]: enum.QoS.html
 /// [`Pid`]: struct.Pid.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "derive", derive(Serialize, Deserialize))]
 pub enum QosPid {
     AtMostOnce,
     AtLeastOnce(Pid),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::{Buf, BufMut};
 #[cfg(feature = "derive")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -104,10 +104,10 @@ impl Pid {
     pub fn get(self) -> u16 {
         self.0.get()
     }
-    pub(crate) fn from_buffer(buf: &mut BytesMut) -> Result<Self, Error> {
-        Self::try_from(buf.split_to(2).get_u16())
+    pub(crate) fn from_buffer(buf: &mut impl Buf) -> Result<Self, Error> {
+        Self::try_from(buf.get_u16())
     }
-    pub(crate) fn to_buffer(self, buf: &mut BytesMut) -> Result<(), Error> {
+    pub(crate) fn to_buffer(self, buf: &mut impl BufMut) -> Result<(), Error> {
         Ok(buf.put_u16(self.get()))
     }
 }


### PR DESCRIPTION
I was waiting to test the API client-side before opening this PR, but it looks like I won't have time to convert my client to newer mqttrs/bytes/async crates for a while, so we may as well merge this in its current form and deal with other potential changes later.

The change to bytes 0.5 is significant, as it is required to support async/await, and a large part of the rust ecosystem is busy migrating to that. One thing we could do if we wanted to support using mqttrs from older codebases is to reexport `bytes::*` from mqttrs, so a project could use bytes 0.4 internally and bytes 0.5 when dealing with mqttrs. I can add that commit if you want.

It'd be nice to get a release out, as I've just realized that `mqttest` cannot get published on crates.io until it starts using a crates.io version of mqttrs.