### PR TITLE
Allow usage in nostd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Cargo.lock
 Cargo.lock
 
 **/*.sw*
+
+# Test output from proptest
+/proptest-regressions/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,15 @@ categories = ["encoding", "network-programming"]
 license = "Apache-2.0"
 
 [features]
+default = ["std"]
+
 # Implements serde::{Serialize,Deserialize} on mqttrs::Pid.
 derive = ["serde"]
+std = ["bytes/std", "serde/std"]
 
 [dependencies]
-bytes = "0.5"
+bytes = { version = "0.5", default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 proptest = "0.9.4"
-

--- a/src/codec_test.rs
+++ b/src/codec_test.rs
@@ -1,7 +1,9 @@
 use crate::*;
 use bytes::BytesMut;
 use proptest::{bool, collection::vec, num::*, prelude::*};
-use std::convert::TryFrom;
+use core::convert::TryFrom;
+use alloc::string::String;
+use alloc::format;
 
 // Proptest strategies to generate packet elements
 prop_compose! {
@@ -15,7 +17,7 @@ prop_compose! {
     }
 }
 prop_compose! {
-    fn stg_pid()(pid in 1..std::u16::MAX) -> Pid {
+    fn stg_pid()(pid in 1..core::u16::MAX) -> Pid {
         Pid::try_from(pid).unwrap()
     }
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,4 +1,5 @@
 use crate::{decoder::*, encoder::*, *};
+use alloc::{string::String, vec::Vec};
 use bytes::{Buf, BufMut, BytesMut};
 
 /// Protocol version.

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use alloc::{string::String, vec::Vec};
 use bytes::{Buf, BytesMut};
 
 /// Decode bytes from a [BytesMut] buffer as a [Packet] enum.
@@ -137,6 +138,7 @@ pub(crate) fn read_bytes(buf: &mut BytesMut) -> Result<Vec<u8>, Error> {
 #[cfg(test)]
 mod test {
     use crate::decoder::*;
+    use alloc::vec;
 
     macro_rules! header {
         ($t:ident, $d:expr, $q:ident, $r:expr) => {

--- a/src/decoder_test.rs
+++ b/src/decoder_test.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use alloc::string::{String, ToString};
 use bytes::BytesMut;
 
 fn bm(d: &[u8]) -> BytesMut {

--- a/src/encoder_test.rs
+++ b/src/encoder_test.rs
@@ -1,6 +1,8 @@
 use crate::*;
 use bytes::BytesMut;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
+use alloc::string::ToString;
+use alloc::vec;
 
 macro_rules! assert_decode {
     ($res:pat, $pkt:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,13 @@
 //! [decode()]: fn.decode.html
 //! [bytes::BytesMut]: https://docs.rs/bytes/0.5.3/bytes/struct.BytesMut.html
 
+#![cfg_attr(not(test), no_std)]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
+
 mod connect;
 mod decoder;
 mod encoder;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -7,7 +7,7 @@ use crate::*;
 ///
 /// ```
 /// # use mqttrs::*;
-/// # use std::convert::TryFrom;
+/// # use core::convert::TryFrom;
 /// // Simplest form
 /// let pkt = Packet::Connack(Connack { session_present: false,
 ///                                     code: ConnectReturnCode::Accepted });

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -1,5 +1,6 @@
 use crate::{decoder::*, encoder::*, *};
 use bytes::{BufMut, BytesMut};
+use alloc::{string::String, vec::Vec};
 
 /// Publish packet ([MQTT 3.3]).
 ///

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -2,6 +2,7 @@ use crate::{decoder::*, encoder::*, *};
 use bytes::{Buf, BufMut, BytesMut};
 #[cfg(feature = "derive")]
 use serde::{Deserialize, Serialize};
+use alloc::{string::String, vec::Vec};
 
 /// Subscribe topic.
 ///


### PR DESCRIPTION
Move all std dependent stuff behind `std` feature-flag, to allow usage in no-std environments, together with an allocator.

Note: This still requires a global allocator! The next step towards suiting it for usage in embedded in general, would be to move `String` and `Vec` behind an `alloc` feature-flag, and either use more slices, or a crate like `Heapless` for the cases where `alloc` is not defined.

Note 2: Not using `std`, means that the catch all error, using the `std::error::Error` trait cannot be used, as it currently has a strict dependency on `std`, but this shouldn't be a problem, as `std::io` will not be used in any `no_std` context anyways. 

Fixes #21 