### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3 (unreleased)
+# 0.3 (2020-03-23)
 
 ## API changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttrs"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["00imvj00 <vijaybambhaniya007@gmail.com>",
            "Vincent de Phily <moltonel@gmail.com>",
            "Mathias Koch <smilykoch@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ packet).
 
 ## Usage
 
-Add `mqttrs = "0.2"` and `bytes = "0.5"` to your `Cargo.toml`.
+Add `mqttrs = "0.3"` and `bytes = "0.5"` to your `Cargo.toml`.
 
 ```rust
 use mqttrs::*;
@@ -49,7 +49,7 @@ assert_eq!(Err(Error::InvalidHeader), decode(&mut garbage));
 
 ## Optional [serde](https://serde.rs/) support.
 
-Use  `mqttrs = { version = "0.2", features = [ "derive" ] }` in your `Cargo.toml`.
+Use  `mqttrs = { version = "0.3", features = [ "derive" ] }` in your `Cargo.toml`.
 
 Enabling this features adds `#[derive(Deserialize, Serialize)]` to some `mqttrs` types. This
 simplifies storing those structs in a database or file, typically to implement session support (qos,
@@ -60,7 +60,7 @@ functions.
 
 ## Optional `#[no_std]` support.
 
-Use `mqttrs = { version = "0.2", default-features = false }` in your `Cargo.toml` to remove the
+Use `mqttrs = { version = "0.3", default-features = false }` in your `Cargo.toml` to remove the
 default `std` feature.
 
 Disabling this feature comes with the cost of not implementing the `std::error::Error` trait,


### PR DESCRIPTION
This commit just switches "0.2" to "0.3" where appropriate, and set the release date to today in the changelog. I've checked the MSRV and `cargo test`. AFAICS this is ready for `git tag` and `cargo publish`.

While I'm at it, would you like to share the crates.io/github.com publish/release rights with me ? If not, at least consider https://users.rust-lang.org/t/bus-factor-1-for-crates/17046 just in case.