### PR TITLE
Return number of bytes written to buffer from encode()

### DIFF
--- a/src/encoder_test.rs
+++ b/src/encoder_test.rs
@@ -7,7 +7,8 @@ use alloc::vec;
 macro_rules! assert_decode {
     ($res:pat, $pkt:expr) => {
         let mut buf = BytesMut::with_capacity(1024);
-        encode($pkt, &mut buf).unwrap();
+        let written = encode($pkt, &mut buf).unwrap();
+        assert_eq!(written, buf.len());
         match decode(&mut buf) {
             Ok(Some($res)) => (),
             err => assert!(

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -1,6 +1,6 @@
 use crate::{decoder::*, encoder::*, *};
-use bytes::{BufMut, BytesMut};
 use alloc::{string::String, vec::Vec};
+use bytes::{BufMut, BytesMut};
 
 /// Publish packet ([MQTT 3.3]).
 ///
@@ -32,7 +32,7 @@ impl Publish {
             payload: buf.to_vec(),
         })
     }
-    pub(crate) fn to_buffer(&self, buf: &mut impl BufMut) -> Result<(), Error> {
+    pub(crate) fn to_buffer(&self, buf: &mut impl BufMut) -> Result<usize, Error> {
         // Header
         let mut header: u8 = match self.qospid {
             QosPid::AtMostOnce => 0b00110000,
@@ -55,7 +55,8 @@ impl Publish {
                 _ => 4,
             }
             + self.payload.len();
-        write_length(length, buf)?;
+
+        let write_len = write_length(length, buf)? + 1;
 
         // Topic
         write_string(self.topic_name.as_ref(), buf)?;
@@ -70,6 +71,6 @@ impl Publish {
         // Payload
         buf.put_slice(self.payload.as_slice());
 
-        Ok(())
+        Ok(write_len)
     }
 }


### PR DESCRIPTION
This PR add a return value to `encode()`, in order to allow using it with types that implement `BufMut` without keeping track of length, such as raw byte slices as
```
let mut tx_buf: [u8; 2048] = [0; 2048];
let size = encode(&pkt, &mut &mut tx_buf[..])?;
network.write(socket, &tx_buf[..size]);
```