### PR TITLE
Return Error instead of panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Bugfixes
+
+* Return error for invalid version instead of panicking ([#31](https://github.com/00imvj00/mqttrs/pull/31))
+
+
 # 0.3 (2020-03-23)
 
 ## API changes

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -126,7 +126,7 @@ impl Connect {
     pub(crate) fn from_buffer(buf: &mut BytesMut) -> Result<Self, Error> {
         let protocol_name = read_string(buf)?;
         let protocol_level = buf.get_u8();
-        let protocol = Protocol::new(&protocol_name, protocol_level).unwrap();
+        let protocol = Protocol::new(&protocol_name, protocol_level)?;
 
         let connect_flags = buf.get_u8();
         let keep_alive = buf.get_u16();
@@ -136,7 +136,7 @@ impl Connect {
         let last_will = if connect_flags & 0b100 != 0 {
             let will_topic = read_string(buf)?;
             let will_message = read_bytes(buf)?;
-            let will_qod = QoS::from_u8((connect_flags & 0b11000) >> 3).unwrap();
+            let will_qod = QoS::from_u8((connect_flags & 0b11000) >> 3)?;
             Some(LastWill {
                 topic: will_topic,
                 message: will_message,

--- a/src/decoder_test.rs
+++ b/src/decoder_test.rs
@@ -25,6 +25,22 @@ fn test_half_connect() {
 }
 
 #[test]
+fn test_connect_wrong_version() {
+    let mut data = bm(&[
+        0b00010000, 39, 0x00, 0x04, 'M' as u8, 'Q' as u8, 'T' as u8, 'T' as u8, 0x01,
+        0b11001110, // +username, +password, -will retain, will qos=1, +last_will, +clean_session
+        0x00, 0x0a, // 10 sec
+        0x00, 0x04, 't' as u8, 'e' as u8, 's' as u8, 't' as u8, // client_id
+        0x00, 0x02, '/' as u8, 'a' as u8, // will topic = '/a'
+        0x00, 0x07, 'o' as u8, 'f' as u8, 'f' as u8, 'l' as u8, 'i' as u8, 'n' as u8,
+        'e' as u8, // will msg = 'offline'
+        0x00, 0x04, 'r' as u8, 'u' as u8, 's' as u8, 't' as u8, // username = 'rust'
+        0x00, 0x02, 'm' as u8, 'q' as u8, // password = 'mq'
+    ]);
+    assert!(decode(&mut data).is_err(), "Unknown version should return error");
+}
+
+#[test]
 fn test_connect() {
     let mut data = bm(&[
         0b00010000, 39, 0x00, 0x04, 'M' as u8, 'Q' as u8, 'T' as u8, 'T' as u8, 0x04,


### PR DESCRIPTION
Return error from Connect `from_buffer` instead of panicking.

I wrote a test to validate this behavior. You can see it fail here: https://github.com/00imvj00/mqttrs/pull/31/checks?check_run_id=1044928663
And fixed here: https://github.com/00imvj00/mqttrs/runs/1044931680?check_suite_focus=true