### PR TITLE
add new function 'decode_slice_with_len()'

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -34,7 +34,8 @@ pub fn clone_packet(input: &[u8], output: &mut [u8]) -> Result<usize, Error> {
 /// # use mqttrs::*;
 /// # use bytes::*;
 /// // Fill a buffer with encoded data (probably from a `TcpStream`).
-/// let mut buf = BytesMut::from(&[0b00110000, 11,
+/// let mut buf = BytesMut::from(&[
+/// 0b00110000, 11,
 ///                                0, 4, 't' as u8, 'e' as u8, 's' as u8, 't' as u8,
 ///                                'h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8] as &[u8]);
 ///
@@ -52,10 +53,64 @@ pub fn clone_packet(input: &[u8], output: &mut [u8]) -> Result<usize, Error> {
 /// [Packet]: ../enum.Packet.html
 /// [BytesMut]: https://docs.rs/bytes/1.0.0/bytes/struct.BytesMut.html
 pub fn decode_slice<'a>(buf: &'a [u8]) -> Result<Option<Packet<'a>>, Error> {
+    if let Some((_, r)) = decode_slice_with_len(buf)? {
+        Ok(Some(r))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Decode bytes from a [BytesMut] buffer as a [Packet] enum, returning a tuple containing the
+/// number of bytes read from the buffer and the [Packet].
+///
+/// The buf is never actually written to, it only takes a `BytesMut` instead of a `Bytes` to
+/// allow using the same buffer to read bytes from network.
+///
+/// ```
+/// # use mqttrs::*;
+/// # use bytes::*;
+/// // Fill a buffer with encoded data (probably from a `TcpStream`).
+/// // this contains 2 packets worth of data
+/// let mut buf = BytesMut::from(&[
+///     // publish packet
+///     0b00110000, 11,
+///     0, 4, 't' as u8, 'e' as u8, 's' as u8, 't' as u8,
+///     'h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8,
+///     // pingresp packet
+///     0b11010000, 0b00000000,
+/// ] as &[u8]);
+///
+/// // Parse the first packet
+/// // and store the number of bytes that were parsed out
+/// let len = match decode_slice_with_len(&mut buf) {
+///     Ok(Some((len, Packet::Publish(p)))) => {
+///         assert_eq!(p.payload, b"hello");
+///         assert_eq!(len, 13); // only parsed 13 bytes
+///         len
+///     },
+///     // In real code you probably don't want to panic like that ;)
+///     Ok(None) => panic!("not enough data"),
+///     other => panic!("unexpected {:?}", other),
+/// };
+///
+/// // parse the second packet, starting from the end of the first packet:
+/// match decode_slice_with_len(&mut buf[len..]) {
+///     Ok(Some((len, Packet::Pingresp))) => {
+///         assert_eq!(len, 2); // parsed 2 bytes
+///     },
+///     // In real code you probably don't want to panic like that ;)
+///     Ok(None) => panic!("not enough data"),
+///     other => panic!("unexpected {:?}", other),
+/// }
+/// ```
+///
+/// [Packet]: ../enum.Packet.html
+/// [BytesMut]: https://docs.rs/bytes/1.0.0/bytes/struct.BytesMut.html
+pub fn decode_slice_with_len<'a>(buf: &'a [u8]) -> Result<Option<(usize, Packet<'a>)>, Error> {
     let mut offset = 0;
     if let Some((header, remaining_len)) = read_header(buf, &mut offset)? {
         let r = read_packet(header, remaining_len, buf, &mut offset)?;
-        Ok(Some(r))
+        Ok(Some((offset, r)))
     } else {
         // Don't have a full packet
         Ok(None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ mod encoder_test;
 
 pub use crate::{
     connect::{Connack, Connect, ConnectReturnCode, LastWill, Protocol},
-    decoder::{clone_packet, decode_slice},
+    decoder::{clone_packet, decode_slice, decode_slice_with_len},
     encoder::encode_slice,
     packet::{Packet, PacketType},
     publish::Publish,

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -28,12 +28,17 @@ impl<'a> Publish<'a> {
             QoS::ExactlyOnce => QosPid::ExactlyOnce(Pid::from_buffer(buf, offset)?),
         };
 
+        let payload = &buf[*offset..payload_end];
+
+        // update the offset so that it's moved to the end of the payload
+        *offset += payload.len();
+
         Ok(Publish {
             dup: header.dup,
             qospid,
             retain: header.retain,
             topic_name,
-            payload: &buf[*offset..payload_end],
+            payload,
         })
     }
     pub(crate) fn to_buffer(&self, buf: &mut [u8], offset: &mut usize) -> Result<usize, Error> {


### PR DESCRIPTION
This function returns a tuple so that consumers of this library can tell how many bytes were read from the buffer, and attempt to read potential subsequent packets from the same buffer.

this PR also contains a fix for the `Publish::from_buffer()` function which updates the `offset` value appropriately for the payload. this wasn't being done before and the offset would remain pointing to the start of the payload in the buffer.

If there's anything you'd like me to modify here in order to get this merged, let me know.